### PR TITLE
feat: 增加用户可以自定义Base URL、API Key、模型名称

### DIFF
--- a/src/options/constants.ts
+++ b/src/options/constants.ts
@@ -30,6 +30,11 @@ export const PROVIDER_INFO: Record<
     models: ["kimi-k2.5", "moonshot-v1-8k"],
     hint: "K2.5 是当前主力模型。moonshot-v1 是旧版。",
   },
+  custom: {
+    label: "自定义",
+    models: [],
+    hint: "填入任意 OpenAI 兼容接口的 Base URL、API Key 和模型名称。",
+  },
 };
 
 /** 句式 key → 中文名映射 */

--- a/src/options/tabs/Settings.tsx
+++ b/src/options/tabs/Settings.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback } from "react";
 import type { ProviderKey, LLMMultiConfig } from "../../shared/types.ts";
-import { DEFAULT_PROVIDERS, PROVIDER_META, resolveLLMConfig } from "../../shared/types.ts";
+import { DEFAULT_PROVIDERS, resolveLLMConfig } from "../../shared/types.ts";
+
 import { chunkSentences } from "../../shared/llm-adapter.ts";
 import { GlassCard } from "../components/GlassCard.tsx";
 import { PROVIDER_INFO } from "../constants.ts";
 
-const PROVIDER_KEYS: ProviderKey[] = ["gemini", "chatgpt", "deepseek", "qwen", "kimi"];
+const PROVIDER_KEYS: ProviderKey[] = ["gemini", "chatgpt", "deepseek", "qwen", "kimi", "custom"];
 
 const TEST_SENTENCE = "Although the project had been delayed by several unexpected issues, the team managed to deliver a working prototype on time.";
 
@@ -18,7 +19,7 @@ interface SettingsProps {
 export function Settings({ config, configLoading: loading, updateLLM }: SettingsProps) {
   const [activeProvider, setActiveProvider] = useState<ProviderKey>("gemini");
   const [verifyStatus, setVerifyStatus] = useState<Record<ProviderKey, "idle" | "checking" | "ok" | "error">>({
-    gemini: "idle", chatgpt: "idle", deepseek: "idle", qwen: "idle", kimi: "idle",
+    gemini: "idle", chatgpt: "idle", deepseek: "idle", qwen: "idle", kimi: "idle", custom: "idle",
   });
   const [verifyError, setVerifyError] = useState<string>("");
 
@@ -45,6 +46,13 @@ export function Settings({ config, configLoading: loading, updateLLM }: Settings
   const handleModelChange = useCallback((value: string) => {
     const providers = { ...config.llm.providers };
     providers[activeProvider] = { ...providers[activeProvider], model: value };
+    updateLLM({ providers });
+    setVerifyStatus((prev) => ({ ...prev, [activeProvider]: "idle" }));
+  }, [activeProvider, config.llm.providers, updateLLM]);
+
+  const handleBaseUrlChange = useCallback((value: string) => {
+    const providers = { ...config.llm.providers };
+    providers[activeProvider] = { ...providers[activeProvider], baseUrl: value };
     updateLLM({ providers });
     setVerifyStatus((prev) => ({ ...prev, [activeProvider]: "idle" }));
   }, [activeProvider, config.llm.providers, updateLLM]);
@@ -91,6 +99,8 @@ export function Settings({ config, configLoading: loading, updateLLM }: Settings
   const currentProviderConfig = config.llm.providers[activeProvider] ?? DEFAULT_PROVIDERS[activeProvider];
   const providerInfo = PROVIDER_INFO[activeProvider];
   const status = verifyStatus[activeProvider];
+  const isCustom = activeProvider === "custom";
+  const baseUrlValue = currentProviderConfig.baseUrl ?? "";
 
   return (
     <div className="settings-section rv">
@@ -141,17 +151,44 @@ export function Settings({ config, configLoading: loading, updateLLM }: Settings
           <div>
             <div className="settings-label">模型</div>
           </div>
-          <select
-            className="settings-select"
-            value={currentProviderConfig.model}
-            onChange={(e) => handleModelChange(e.target.value)}
-            style={{ minWidth: 180 }}
-          >
-            {providerInfo.models.map((m) => (
-              <option key={m} value={m}>{m}</option>
-            ))}
-          </select>
+          {isCustom ? (
+            <input
+              className="settings-input"
+              type="text"
+              value={currentProviderConfig.model}
+              onChange={(e) => handleModelChange(e.target.value)}
+              placeholder="例如：gpt-4o、claude-3-5-sonnet"
+              style={{ width: 240 }}
+            />
+          ) : (
+            <select
+              className="settings-select"
+              value={currentProviderConfig.model}
+              onChange={(e) => handleModelChange(e.target.value)}
+              style={{ minWidth: 180 }}
+            >
+              {providerInfo.models.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          )}
         </div>
+        {isCustom && (
+          <div className="settings-row" style={{ paddingTop: 4 }}>
+            <div>
+              <div className="settings-label">Base URL</div>
+              <div className="settings-desc">API 服务器地址（OpenAI 兼容格式）</div>
+            </div>
+            <input
+              className="settings-input"
+              type="text"
+              value={baseUrlValue}
+              onChange={(e) => handleBaseUrlChange(e.target.value)}
+              placeholder="https://api.example.com"
+              style={{ width: 240 }}
+            />
+          </div>
+        )}
         <div className="settings-model-info">{providerInfo.hint}</div>
       </GlassCard>
     </div>

--- a/src/shared/llm-adapter.ts
+++ b/src/shared/llm-adapter.ts
@@ -178,8 +178,9 @@ export function parseOpenAIResponse(data: unknown): LLMChunkItem[] {
  * 兼容 markdown fence 包裹和直接 JSON
  */
 export function parseChunkJson(text: string): LLMChunkItem[] {
+  // 剥离 <think>...</think> 推理块（DeepSeek-R1 / MiniMax-M2.5 等 thinking 模型）
+  let cleaned = text.trim().replace(/<think>[\s\S]*?<\/think>/g, "").trim();
   // 去除可能的 markdown fence
-  let cleaned = text.trim();
   const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (fenceMatch) {
     cleaned = fenceMatch[1].trim();
@@ -348,7 +349,7 @@ Return valid JSON only, no markdown fences.`;
  * 解析单条完整分析结果 JSON
  */
 export function parseFullAnalysisJson(text: string): FullAnalysisResult {
-  let cleaned = text.trim();
+  let cleaned = text.trim().replace(/<think>[\s\S]*?<\/think>/g, "").trim();
   const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (fenceMatch) {
     cleaned = fenceMatch[1].trim();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,13 +8,14 @@ export interface LLMConfig {
   model: string;
 }
 
-/** 5 种 Provider */
-export type ProviderKey = "gemini" | "chatgpt" | "deepseek" | "qwen" | "kimi";
+/** 6 种 Provider（含自定义） */
+export type ProviderKey = "gemini" | "chatgpt" | "deepseek" | "qwen" | "kimi" | "custom";
 
 /** 单个 Provider 的存储数据 */
 export interface ProviderConfig {
   apiKey: string;
   model: string;
+  baseUrl?: string; // 自定义 base URL，为空时使用 PROVIDER_META 默认值
 }
 
 /** 多 Provider 存储结构 */
@@ -40,6 +41,7 @@ export const DEFAULT_PROVIDERS: Record<ProviderKey, ProviderConfig> = {
   deepseek: { apiKey: "", model: "deepseek-chat" },
   qwen: { apiKey: "", model: "qwen3-flash" },
   kimi: { apiKey: "", model: "kimi-k2.5" },
+  custom: { apiKey: "", model: "", baseUrl: "" },
 };
 
 export const DEFAULT_CONFIG: BaitConfig = {
@@ -61,6 +63,7 @@ export const PROVIDER_META: Record<ProviderKey, { format: LLMConfig["format"]; b
   deepseek: { format: "openai-compatible", baseUrl: "https://api.deepseek.com", label: "DeepSeek" },
   qwen: { format: "openai-compatible", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode", label: "Qwen" },
   kimi: { format: "openai-compatible", baseUrl: "https://api.moonshot.cn", label: "Kimi" },
+  custom: { format: "openai-compatible", baseUrl: "", label: "自定义" },
 };
 
 /** 从多 Provider 配置中解析出 LLMConfig（给 llm-adapter 用） */
@@ -71,7 +74,7 @@ export function resolveLLMConfig(multi: LLMMultiConfig): LLMConfig {
   return {
     format: meta.format,
     apiKey: pc.apiKey,
-    baseUrl: meta.baseUrl,
+    baseUrl: pc.baseUrl !== undefined && pc.baseUrl !== "" ? pc.baseUrl : meta.baseUrl,
     model: pc.model,
   };
 }


### PR DESCRIPTION
## 改动内容

1. **新增自定义 Provider**
   - 添加"自定义" tab，支持自由填写 Base URL、API Key、模型名称
   - 适用于任意 OpenAI 兼容接口（如 GitCode、自建服务等）
   - 固定 provider（Gemini/ChatGPT/DeepSeek/Qwen/Kimi）保持不变，不显示 Base URL 输入框

2. **JSON 解析优化**
   - 兼容 thinking 模型的 ``` 推理块
   - 在解析 JSON 前自动剥离推理块内容