### PR TITLE
feat: add Xiaomi MiMo as LLM provider

### DIFF
--- a/src/options/constants.ts
+++ b/src/options/constants.ts
@@ -30,6 +30,11 @@ export const PROVIDER_INFO: Record<
     models: ["kimi-k2.5", "moonshot-v1-8k"],
     hint: "K2.5 是当前主力模型。moonshot-v1 是旧版。",
   },
+  mimo: {
+    label: "MiMo",
+    models: ["MiMo-V2-Flash", "MiMo-V2-Pro", "MiMo-V2-Omni", "MiMo-V2-TTS"],
+    hint: "Flash 速度最快。Pro 推理能力最强。Omni 支持多模态。",
+  },
 };
 
 /** 句式 key → 中文名映射 */

--- a/src/options/tabs/Settings.tsx
+++ b/src/options/tabs/Settings.tsx
@@ -5,7 +5,7 @@ import { chunkSentences } from "../../shared/llm-adapter.ts";
 import { GlassCard } from "../components/GlassCard.tsx";
 import { PROVIDER_INFO } from "../constants.ts";
 
-const PROVIDER_KEYS: ProviderKey[] = ["gemini", "chatgpt", "deepseek", "qwen", "kimi"];
+const PROVIDER_KEYS: ProviderKey[] = ["gemini", "chatgpt", "deepseek", "qwen", "kimi", "mimo"];
 
 const TEST_SENTENCE = "Although the project had been delayed by several unexpected issues, the team managed to deliver a working prototype on time.";
 
@@ -18,7 +18,7 @@ interface SettingsProps {
 export function Settings({ config, configLoading: loading, updateLLM }: SettingsProps) {
   const [activeProvider, setActiveProvider] = useState<ProviderKey>("gemini");
   const [verifyStatus, setVerifyStatus] = useState<Record<ProviderKey, "idle" | "checking" | "ok" | "error">>({
-    gemini: "idle", chatgpt: "idle", deepseek: "idle", qwen: "idle", kimi: "idle",
+    gemini: "idle", chatgpt: "idle", deepseek: "idle", qwen: "idle", kimi: "idle", mimo: "idle",
   });
   const [verifyError, setVerifyError] = useState<string>("");
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,8 +8,8 @@ export interface LLMConfig {
   model: string;
 }
 
-/** 5 种 Provider */
-export type ProviderKey = "gemini" | "chatgpt" | "deepseek" | "qwen" | "kimi";
+/** 6 种 Provider */
+export type ProviderKey = "gemini" | "chatgpt" | "deepseek" | "qwen" | "kimi" | "mimo";
 
 /** 单个 Provider 的存储数据 */
 export interface ProviderConfig {
@@ -40,6 +40,7 @@ export const DEFAULT_PROVIDERS: Record<ProviderKey, ProviderConfig> = {
   deepseek: { apiKey: "", model: "deepseek-chat" },
   qwen: { apiKey: "", model: "qwen3-flash" },
   kimi: { apiKey: "", model: "kimi-k2.5" },
+  mimo: { apiKey: "", model: "MiMo-V2-Flash" },
 };
 
 export const DEFAULT_CONFIG: BaitConfig = {
@@ -61,6 +62,7 @@ export const PROVIDER_META: Record<ProviderKey, { format: LLMConfig["format"]; b
   deepseek: { format: "openai-compatible", baseUrl: "https://api.deepseek.com", label: "DeepSeek" },
   qwen: { format: "openai-compatible", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode", label: "Qwen" },
   kimi: { format: "openai-compatible", baseUrl: "https://api.moonshot.cn", label: "Kimi" },
+  mimo: { format: "openai-compatible", baseUrl: "https://api.xiaomimimo.com", label: "MiMo" },
 };
 
 /** 从多 Provider 配置中解析出 LLMConfig（给 llm-adapter 用） */


### PR DESCRIPTION
## Summary
- Add Xiaomi MiMo (platform.xiaomimimo.com) as the 6th LLM provider
- Uses OpenAI-compatible API format, base URL: `https://api.xiaomimimo.com`
- Supports 4 models: MiMo-V2-Flash (default), MiMo-V2-Pro, MiMo-V2-Omni, MiMo-V2-TTS

## Changes
- `src/shared/types.ts` — Added `"mimo"` to `ProviderKey`, `DEFAULT_PROVIDERS`, `PROVIDER_META`
- `src/options/constants.ts` — Added MiMo to `PROVIDER_INFO` with model list and hints
- `src/options/tabs/Settings.tsx` — Added MiMo to `PROVIDER_KEYS` array and `verifyStatus`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Settings page shows MiMo as a provider option
- [x] Can input API key and select model for MiMo
- [x] Test connection works with a valid MiMo API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)